### PR TITLE
`add` github flow explanation to [readme]

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ for example, look at pr #1.
 ---
 ### why merge for dev -> main?
 
+we use merge for dev -> main because of the fact that we only use squashes so the developers don't have to worry and it makes sense in the context of github flow.
+
+we use merges, because of instead of squashing all of the new developer commits into one commit for main, we instead make the `main` branch be a snapshot of the latest production-ready (new-version-ready) `dev` branch, and tag the main branch for both CD purposes and to mark previous version releases.
 
 ---
 ---

--- a/README.md
+++ b/README.md
@@ -100,6 +100,13 @@ a small explanatoin of a hotfix workflow:
 ---
 ### why squash for feature -> dev?
 
+we use squash when we do feature -> dev because it allows for the commits inside of the pr's `feature` branch to be anything (the developer doesn't have to worry about commit conventions), and then when the pr is finished it gets squashed into dev as a `hrcc` commit.
+
+if we didn't do this, it would require every developer to follow commit conventions and have to worry about all of that stuff. it's better for both ends.
+
+instead of every commit having to be formatted correctly, they just make sure the pr is named correctly according to `hrcc` and then they're done.
+
+for example, look at pr #1.
 
 ---
 ### why merge for dev -> main?

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Progress:
 
 ## pr naming scheme: `hrpr`
 
-
+---
 ## github flow description
 
 Github Flow is a lightweight, branch-based git workflow.
@@ -39,6 +39,20 @@ The main concepts I will be adressing here are these:
 - hotfix branches
 - why we use squash when we do feature -> dev prs
 - why we use merge when we use dev -> main prs
+
+### main branch
+
+### dev branch
+
+### feature branches
+
+### hotfix branches
+
+### why squash for feature -> dev?
+
+### why merge for dev -> main?
+
+---
 
 ## how to prs guide
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ this is also the only branch allowed to be merged into `main`.
 
 ### feature branches
 
+these branches are the *pr branches*.
+
+basically, these branches are the `from` in `from -> to`, where `to` is always `dev`.
+
+the commits on these branches do not have to follow the `hrcc`, because when these are squash-commited, it will provide `hrcc` commits to the actual branches that have changelogs.
+
+these branches are allowed allow to be squashed, and only into `dev`.
 
 ---
 ### hotfix branches

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The main concepts I will be adressing here are these:
 
 the main branch in a github flow repository is `main`. it could also be called `master`, `trunk`, etc.
 
-this branch is best described as the `production` branch.
+this branch is best described as the *production* branch.
 
 whenever you make a pr from dev (main development branch) to this branch, you are essentially releasing a new version of your software.
 
@@ -60,13 +60,32 @@ tagging also allows for easy CD.
 
 ### dev branch
 
+the dev branch in a github flow repository is usually `dev`. it could also be called `develop`, `development`, `devel`, among other things.
+
+this branch is best described as *the latest development version*.
+
+all feature branches eventually end up squashed into here.
+
+this is the only branch besides `main` who has `hrcc` commit histories.
+
+this is also the only branch allowed to be merged into `main`.
+
+---
+
 ### feature branches
 
+
+---
 ### hotfix branches
 
+
+---
 ### why squash for feature -> dev?
 
+
+---
 ### why merge for dev -> main?
+
 
 ---
 ---

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ this branch is best described as the *production* branch.
 
 whenever you make a pr from dev (main development branch) to this branch, you are essentially releasing a new version of your software.
 
-what version means is up to you.
+what a version means is up to you.
 
 whenever you release a new version, you tag it (`git tag` or github's web ui).
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Progress:
 ## pr naming scheme: `hrpr`
 
 ---
+---
 ## github flow description
 
 Github Flow is a lightweight, branch-based git workflow.
@@ -40,7 +41,22 @@ The main concepts I will be adressing here are these:
 - why we use squash when we do feature -> dev prs
 - why we use merge when we use dev -> main prs
 
+---
 ### main branch
+
+the main branch in a github flow repository is `main`. it could also be called `master`, `trunk`, etc.
+
+this branch is best described as the `production` branch.
+
+whenever you make a pr from dev (main development branch) to this branch, you are essentially releasing a new version of your software.
+
+what version means is up to you.
+
+whenever you release a new version, you tag it (`git tag` or github's web ui).
+
+tagging also allows for easy CD.
+
+---
 
 ### dev branch
 
@@ -52,6 +68,7 @@ The main concepts I will be adressing here are these:
 
 ### why merge for dev -> main?
 
+---
 ---
 
 ## how to prs guide

--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ Progress:
 
 ## github flow description
 
+Github Flow is a lightweight, branch-based git workflow.
+
+The main concepts I will be adressing here are these:
+
+- the main (prod) branch
+- the dev (develop) branch
+- feature branches
+- hotfix branches
+- why we use squash when we do feature -> dev prs
+- why we use merge when we use dev -> main prs
+
 ## how to prs guide
 
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ these branches are allowed allow to be squashed, and only into `dev`.
 ---
 ### hotfix branches
 
+these branches are the branches that are used to fix important issues in the `main` branch.
+
+essentially, if you accidentally push a very severe bug to `main`, you would use a hotfix branch in order to fix it.
+
+a small explanatoin of a hotfix workflow:
+
+- created off latest `main`
+- only commits allowed on hotfix are about issue
+- no feature enhancements or chores (`feat` or `chore` in *`hrcc`*)
+- merges into both master & develop branches when its finished
+- deleted after merge
 
 ---
 ### why squash for feature -> dev?


### PR DESCRIPTION
### adding git flow to the readme

this pr will introduce the follow concepts into the readme

- [x] main (prod) branch
- [x] dev (develop) branch
- [x] feature branches (such as this pr's branch)
- [x] hotfix branches
- [x] why we don't enforce the commit convention in pr commits, but do in the pr's squash commit
- [x] why we use squash instead of merge for prs -> dev
- [x] why we use merge for dev -> main prs

todo:
- [x] outline section
- [x] describe all the of the above concepts
- [x] make sure it makes sense